### PR TITLE
hotfix: issue #6 directory path split fixed

### DIFF
--- a/js/generationFunctions.js
+++ b/js/generationFunctions.js
@@ -79,7 +79,7 @@ function getPathsFromHTTPRequest(response){
     var firstSplit = response.split("201: ");
 
     for(i=1;i<firstSplit.length;i++){
-        var secondSplit = firstSplit[i].split(" 4096");
+        var secondSplit = firstSplit[i].split(" ");
         res[i-1] = secondSplit[0];
     }
 


### PR DESCRIPTION
Error was found in generating info from directory path. The cause is the way the path were being obtained, now fixed and functional.